### PR TITLE
fix: logger override priority

### DIFF
--- a/src/service/logger.ts
+++ b/src/service/logger.ts
@@ -24,7 +24,7 @@ export function createLogger({
         ignore: 'label',
       },
     },
-  }, config.LOGGERS && config.LOGGERS[label], options), pino.destination(destination))
+  }, config.LOGGERS?.base, config.LOGGERS && config.LOGGERS[label], options), pino.destination(destination))
 }
 
 export default createLogger


### PR DESCRIPTION
LOGGER > base should always been applied for new loggers.